### PR TITLE
H1〜H6のフォントサイズ変更

### DIFF
--- a/_plugins/kramdown_tag_override.rb
+++ b/_plugins/kramdown_tag_override.rb
@@ -52,8 +52,24 @@ module HtmlTagExtended
 
   def convert_header(el, indent)
 
-    level = output_header_level(el.options[:level])    
-    add_class = "mdc-typography--headline#{level}"
+    level = output_header_level(el.options[:level])
+    add_class =
+      case level
+      when 1
+        'mdc-typography--headline3'
+      when 2
+        'mdc-typography--headline4'
+      when 3
+        'mdc-typography--headline5'
+      when 4
+        'mdc-typography--headline6'
+      when 5
+        'mdc-typography--subtitle1'
+      when 6
+        'mdc-typography--subtitle2'
+      else
+        ''
+      end
     new_attr = add_class_attribute(el.attr, add_class)
 
     el.attr.replace(new_attr)


### PR DESCRIPTION
mdc-typographyの`mdc-typography--headline1`から`mdc-typography--headline6`は別にそのままH1〜H6に当てなくてもいいらしい。

デザインに応じて適宜選んでいいようなので、変更